### PR TITLE
Limit uploaded file size

### DIFF
--- a/fileupload/templates/fileupload/submission_basic_form.html
+++ b/fileupload/templates/fileupload/submission_basic_form.html
@@ -60,6 +60,7 @@ $(function () {
         $('#fileupload').fileupload({
             url: '/upload/basic/',
             crossDomain: false,
+            maxFileSize: 10240000, // 10MB
             formData: {
                 problem_pk: $('#form_task option:selected').val(),
             },


### PR DESCRIPTION
This can be done by looking at an old stub of fileuploader project here: https://github.com/infoclock/OlympicTracker/tree/refactor/fileupload/templates/fileupload .

Don't limit with Django, it's useless if one sends a large file: http://stackoverflow.com/questions/2472422/django-file-upload-size-limit#2472426
